### PR TITLE
refactor: update API routes to remove versioning

### DIFF
--- a/apps/api/internal/handlers/households.go
+++ b/apps/api/internal/handlers/households.go
@@ -16,7 +16,7 @@ func NewHouseholdsHandler(svc *service.HouseholdService) *HouseholdsHandler {
 	return &HouseholdsHandler{svc: svc}
 }
 
-// List handles GET /v1/households
+// List handles GET /households
 // Returns all households (for dev mode / household selection)
 func (h *HouseholdsHandler) List(w http.ResponseWriter, r *http.Request) {
 	households, err := h.svc.List(r.Context())

--- a/apps/api/internal/handlers/media.go
+++ b/apps/api/internal/handlers/media.go
@@ -91,7 +91,7 @@ func parseHouseholdID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) 
 	return householdID, true
 }
 
-// Upload handles POST /v1/media/upload
+// Upload handles POST /media/upload
 func (h *MediaHandler) Upload(w http.ResponseWriter, r *http.Request) {
 	householdID, ok := parseHouseholdID(w, r)
 	if !ok {
@@ -198,7 +198,7 @@ func populateItemMetadata(item *models.MediaItem, meta *ImageMetadata) {
 	item.FocalLength = meta.FocalLength
 }
 
-// List handles GET /v1/media
+// List handles GET /media
 func (h *MediaHandler) List(w http.ResponseWriter, r *http.Request) {
 	householdID, ok := parseHouseholdID(w, r)
 	if !ok {
@@ -235,7 +235,7 @@ func (h *MediaHandler) List(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// Get handles GET /v1/media/{id}
+// Get handles GET /media/{id}
 func (h *MediaHandler) Get(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseMediaID(w, r)
 	if !ok {
@@ -250,7 +250,7 @@ func (h *MediaHandler) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"item": item})
 }
 
-// Download handles GET /v1/media/{id}/download
+// Download handles GET /media/{id}/download
 func (h *MediaHandler) Download(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseMediaID(w, r)
 	if !ok {
@@ -286,7 +286,7 @@ func (h *MediaHandler) Download(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, fullPath)
 }
 
-// Original handles GET /v1/media/{id}/original
+// Original handles GET /media/{id}/original
 func (h *MediaHandler) Original(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseMediaID(w, r)
 	if !ok {
@@ -316,7 +316,7 @@ func (h *MediaHandler) Original(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, fullPath)
 }
 
-// Thumbnail handles GET /v1/media/{id}/thumbnail
+// Thumbnail handles GET /media/{id}/thumbnail
 func (h *MediaHandler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseMediaID(w, r)
 	if !ok {
@@ -349,7 +349,7 @@ func (h *MediaHandler) Thumbnail(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, fullPath)
 }
 
-// Delete handles DELETE /v1/media/{id}
+// Delete handles DELETE /media/{id}
 func (h *MediaHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseMediaID(w, r)
 	if !ok {

--- a/apps/api/internal/handlers/users.go
+++ b/apps/api/internal/handlers/users.go
@@ -16,7 +16,7 @@ func NewUserHandler(svc *service.UserService) *UserHandler {
 	return &UserHandler{svc: svc}
 }
 
-// GetMe handles the /v1/me endpoint
+// GetMe handles the /me endpoint
 // Dev auth: provide X-Dev-User header as external_sub (temporary)
 func (h *UserHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 	sub := r.Header.Get("X-Dev-User")

--- a/apps/api/internal/server/server.go
+++ b/apps/api/internal/server/server.go
@@ -70,22 +70,22 @@ func (s *Server) setupRoutes() {
 	s.router.Get("/health/db", healthHandler.HealthDB)
 
 	// User routes
-	s.router.Get("/v1/me", userHandler.GetMe)
+	s.router.Get("/me", userHandler.GetMe)
 
 	// Logs routes
-	s.router.Get("/v1/logs/stream", logsHandler.StreamLogs)
+	s.router.Get("/logs/stream", logsHandler.StreamLogs)
 
 	// Households routes
-	s.router.Get("/v1/households", householdsHandler.List)
+	s.router.Get("/households", householdsHandler.List)
 
 	// Media routes
-	s.router.Post("/v1/media/upload", mediaHandler.Upload)
-	s.router.Get("/v1/media", mediaHandler.List)
-	s.router.Get("/v1/media/{id}", mediaHandler.Get)
-	s.router.Get("/v1/media/{id}/download", mediaHandler.Download)
-	s.router.Get("/v1/media/{id}/thumbnail", mediaHandler.Thumbnail)
-	s.router.Get("/v1/media/{id}/original", mediaHandler.Original)
-	s.router.Delete("/v1/media/{id}", mediaHandler.Delete)
+	s.router.Post("/media/upload", mediaHandler.Upload)
+	s.router.Get("/media", mediaHandler.List)
+	s.router.Get("/media/{id}", mediaHandler.Get)
+	s.router.Get("/media/{id}/download", mediaHandler.Download)
+	s.router.Get("/media/{id}/thumbnail", mediaHandler.Thumbnail)
+	s.router.Get("/media/{id}/original", mediaHandler.Original)
+	s.router.Delete("/media/{id}", mediaHandler.Delete)
 }
 
 func (s *Server) Start() error {

--- a/apps/web/app/api/media/[id]/route.ts
+++ b/apps/web/app/api/media/[id]/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const { id } = await params
 
   try {
-    const response = await fetch(`${getApiBaseUrl()}/v1/media/${id}`, {
+    const response = await fetch(`${getApiBaseUrl()}/media/${id}`, {
       headers: getApiHeaders()
     })
 
@@ -30,7 +30,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   const { id } = await params
 
   try {
-    const response = await fetch(`${getApiBaseUrl()}/v1/media/${id}`, {
+    const response = await fetch(`${getApiBaseUrl()}/media/${id}`, {
       method: 'DELETE',
       headers: getApiHeaders()
     })

--- a/apps/web/app/api/media/route.ts
+++ b/apps/web/app/api/media/route.ts
@@ -10,9 +10,9 @@ export async function GET(request: NextRequest) {
 
   const params = new URLSearchParams({ page, pageSize })
   if (type) params.set('type', type)
-  console.log('getApiBaseUrl', getApiBaseUrl())
+
   try {
-    const response = await fetch(`${getApiBaseUrl()}/v1/media?${params}`, {
+    const response = await fetch(`${getApiBaseUrl()}/media?${params}`, {
       headers: getApiHeaders()
     })
 
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
 
-    const response = await fetch(`${getApiBaseUrl()}/v1/media/upload`, {
+    const response = await fetch(`${getApiBaseUrl()}/media/upload`, {
       method: 'POST',
       headers: getApiHeaders(),
       body: formData

--- a/apps/web/hooks/use-logs-stream.ts
+++ b/apps/web/hooks/use-logs-stream.ts
@@ -40,7 +40,7 @@ function getLogsWsUrl(params: URLSearchParams): string | null {
   }
 
   const port = process.env.NEXT_PUBLIC_PI_PORT || '8080'
-  return `ws://${host}:${port}/v1/logs/stream?${params}`
+  return `ws://${host}:${port}/logs/stream?${params}`
 }
 
 export function useLogsStream(
@@ -72,7 +72,6 @@ export function useLogsStream(
         'WebSocket URL not configured. Set NEXT_PUBLIC_PI_HOST in .env and restart the dev server.',
         { NEXT_PUBLIC_PI_HOST: process.env.NEXT_PUBLIC_PI_HOST }
       )
-      // Avoid calling setState() synchronously; use microtask to defer setError
       setErrorEvent('Set NEXT_PUBLIC_PI_HOST in .env and restart dev server')
       return
     }


### PR DESCRIPTION
- Changed endpoint paths for households, media, and user routes to remove the "/v1" prefix, simplifying the API structure.
- Updated corresponding fetch calls in the web application to align with the new endpoint paths.