### PR TITLE
feat: add web-optimized WebP image generation for faster photo loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-/storage-api
+storage-api
 *.exe
 *.exe~
 *.dll

--- a/apps/api/backfill-webp.sh
+++ b/apps/api/backfill-webp.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+
+# Load environment variables
+if [ -f "$SCRIPT_DIR/.env" ]; then
+  set -a
+  source "$SCRIPT_DIR/.env"
+  set +a
+elif [ -f "$SCRIPT_DIR/../../.env" ]; then
+  set -a
+  source "$SCRIPT_DIR/../../.env"
+  set +a
+else
+  echo "No .env file found. Make sure DATABASE_URL and MEDIA_PATH are set."
+fi
+
+echo "Running WebP backfill..."
+echo "MEDIA_PATH: ${MEDIA_PATH:-/mnt/storage/media}"
+
+cd "$SCRIPT_DIR"
+
+# Use compiled binary if available, otherwise fall back to go run
+if [ -f "./backfill-webp" ]; then
+  ./backfill-webp
+else
+  go run ./cmd/backfill-webp/main.go
+fi

--- a/apps/api/cmd/backfill-webp/main.go
+++ b/apps/api/cmd/backfill-webp/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"storage-api/internal/config"
+	"storage-api/internal/db"
+	"storage-api/internal/handlers"
+	"storage-api/internal/models"
+)
+
+func main() {
+	cfg := config.Load()
+
+	gormDB, err := db.New(cfg.DSN)
+	if err != nil {
+		log.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer db.Close(gormDB)
+
+	ctx := context.Background()
+
+	// Find all photos without web_path
+	var photos []models.MediaItem
+	result := gormDB.WithContext(ctx).
+		Where("type = ?", "photo").
+		Where("web_path IS NULL OR web_path = ''").
+		Find(&photos)
+
+	if result.Error != nil {
+		log.Fatalf("Failed to query photos: %v", result.Error)
+	}
+
+	log.Printf("Found %d photos to backfill", len(photos))
+
+	mediaPath := os.Getenv("MEDIA_PATH")
+	if mediaPath == "" {
+		mediaPath = "/mnt/storage/media"
+	}
+
+	successCount := 0
+	errorCount := 0
+
+	for i, photo := range photos {
+		log.Printf("[%d/%d] Processing %s", i+1, len(photos), photo.Path)
+
+		// Determine source path (use preview for HEIC, otherwise original)
+		srcPath := photo.Path
+		if photo.PreviewPath != "" {
+			srcPath = photo.PreviewPath
+		}
+		fullSrcPath := fmt.Sprintf("%s/%s", mediaPath, srcPath)
+
+		// Generate WebP
+		webFull, webRel, err := handlers.GenerateWebOptimizedImage(fullSrcPath, photo.Path)
+		if err != nil {
+			log.Printf("  ERROR: %v", err)
+			errorCount++
+			continue
+		}
+
+		// Update database
+		updateResult := gormDB.WithContext(ctx).
+			Model(&models.MediaItem{}).
+			Where("id = ?", photo.ID).
+			Update("web_path", webRel)
+
+		if updateResult.Error != nil {
+			log.Printf("  ERROR updating database: %v", updateResult.Error)
+			os.Remove(webFull) // Clean up generated file
+			errorCount++
+			continue
+		}
+
+		log.Printf("  OK: %s", webRel)
+		successCount++
+	}
+
+	log.Printf("Backfill complete: %d success, %d errors", successCount, errorCount)
+}

--- a/apps/api/deploy.sh
+++ b/apps/api/deploy.sh
@@ -11,6 +11,7 @@ git pull origin main
 
 echo "🔨 Building application..."
 go build -o storage-api ./cmd/server
+go build -o backfill-webp ./cmd/backfill-webp
 
 echo "🗄️  Running migrations..."
 ./migrate.sh

--- a/apps/api/internal/models/media.go
+++ b/apps/api/internal/models/media.go
@@ -23,9 +23,10 @@ type MediaItem struct {
 	CreatedAt   time.Time  `gorm:"autoCreateTime" json:"createdAt"`
 	UpdatedAt   time.Time  `gorm:"autoUpdateTime" json:"updatedAt"`
 
-	// Preview, thumbnail, and original file paths
+	// Preview, thumbnail, web-optimized, and original file paths
 	PreviewPath      string `gorm:"size:512" json:"previewPath,omitempty"`
 	ThumbnailPath    string `gorm:"size:512" json:"thumbnailPath,omitempty"`
+	WebPath          string `gorm:"size:512" json:"webPath,omitempty"`
 	OriginalFilename string `gorm:"size:255" json:"originalFilename,omitempty"`
 
 	// Camera metadata (from EXIF)

--- a/apps/api/migrations/20260128000000_add_web_path.sql
+++ b/apps/api/migrations/20260128000000_add_web_path.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE storage_items ADD COLUMN web_path TEXT;
+
+-- +goose Down
+ALTER TABLE storage_items DROP COLUMN IF EXISTS web_path;

--- a/apps/web/app/media/[id]/page.tsx
+++ b/apps/web/app/media/[id]/page.tsx
@@ -19,7 +19,7 @@ import {
   Loader2
 } from 'lucide-react'
 import { useMediaItem } from '@/hooks/use-media'
-import { getMediaUrl } from '@/lib/media-api'
+import { getMediaUrl, getOriginalMediaUrl } from '@/lib/media-api'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { MediaItem } from '@/lib/types/media'
@@ -85,7 +85,7 @@ function MediaHeader({ id, filename }: { id: string; filename?: string }) {
           </Button>
         </Link>
         <div className='flex-1' />
-        <a href={getMediaUrl(id)} download={filename || `media-${id}`}>
+        <a href={getOriginalMediaUrl(id)} download={filename || `media-${id}`}>
           <Button variant='outline' size='sm'>
             <Download className='size-4 mr-2' />
             Download

--- a/apps/web/lib/media-api.ts
+++ b/apps/web/lib/media-api.ts
@@ -54,6 +54,15 @@ export function getMediaUrl(id: string): string {
   return `/api/media/${id}/download`
 }
 
+/**
+ *
+ * @param id - The ID of the media item
+ * @returns The URL of the original media file
+ */
+export function getOriginalMediaUrl(id: string): string {
+  return `/api/media/${id}/original`
+}
+
 export function getThumbnailUrl(id: string): string {
   return `/api/media/${id}/thumbnail`
 }


### PR DESCRIPTION
- Generate 2400px max WebP versions of photos on upload using cwebp
- Add WebPath field to MediaItem model with migration
- Update download endpoint to prefer WebP > preview > original
- Include backfill command and script for existing photos
- Clean up WebP files on media deletion and conflict